### PR TITLE
subject 인증 오류

### DIFF
--- a/backend/src/main/java/com/tukorea/cogTest/domain/Subject.java
+++ b/backend/src/main/java/com/tukorea/cogTest/domain/Subject.java
@@ -95,6 +95,8 @@ public class Subject extends User{
                 .id(this.id)
                 .age(this.age)
                 .name(this.name)
+                .username(this.getUsername())
+                .password(this.getPassword())
                 .career(this.career)
                 .field(this.field)
                 .remarks(this.remarks)


### PR DESCRIPTION
subjectService의 findSubject가 SubjectDTO를 반환함.
이때 SubjectDTO의 username, password 파라미터가 항상 null로 입력됨.
그래서 jwtFilter에서 유저 조회 후 인증객체를 생성할 때 user.getUsername()에서 오류가 발생함.

DTO를 바꾸는 로직에 username, password를 채우도록 변경함