### PR TITLE
super admin으로 admin 삭제 안되는 버그

### DIFF
--- a/backend/src/main/java/com/tukorea/cogTest/domain/Subject.java
+++ b/backend/src/main/java/com/tukorea/cogTest/domain/Subject.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.Hibernate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.util.List;
 import java.util.Objects;
 
 @Entity(name = "subject")
@@ -38,6 +39,9 @@ public class Subject extends User{
     @ManyToOne
     @JoinColumn(name="field_id")
     private Field field;
+
+    @OneToMany(mappedBy = "target", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<TestResult> testResults;
 
     @Builder
     public Subject(

--- a/backend/src/main/java/com/tukorea/cogTest/service/AdminServiceImpl.java
+++ b/backend/src/main/java/com/tukorea/cogTest/service/AdminServiceImpl.java
@@ -14,6 +14,7 @@ import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.BufferedReader;
@@ -28,6 +29,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 @Slf4j
 @RequiredArgsConstructor
+@Transactional
 public class AdminServiceImpl implements AdminService {
 
     private final AdminRepository adminRepository;


### PR DESCRIPTION
admin을 삭제할 때 admin이 가지는 모든 subject들을 삭제함.
이때 subject의 키를 외래키로 하는 test result들이 문제가 됨.

그래서 subject의 속성으로 test result들을 가지도록 양방향 매핑하고 cascading 전략을 remove를 주어서 subject가 삭제될 때 test result도 삭제되도록 함.