### PR TITLE
admin 삭제 로직 변경과 site 보안 정책 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -8,7 +8,7 @@ jar{
 }
 
 group = 'com.tukorea'
-version = '0.0.83-SNAPSHOT'
+version = '0.1.0-SNAPSHOT'
 sourceCompatibility = '17'
 
 configurations {

--- a/backend/src/main/java/com/tukorea/cogTest/domain/Field.java
+++ b/backend/src/main/java/com/tukorea/cogTest/domain/Field.java
@@ -48,6 +48,9 @@ public class Field {
     public void appendWorkerNum(){
         numOfWorkers++;
     }
+    public void decreaseWorkerNum(){
+        numOfWorkers--;
+    }
 
     public Field update(Field field){
         this.name = field.getName();

--- a/backend/src/main/java/com/tukorea/cogTest/security/filter/JwtFilter.java
+++ b/backend/src/main/java/com/tukorea/cogTest/security/filter/JwtFilter.java
@@ -93,7 +93,7 @@ public class JwtFilter extends OncePerRequestFilter {
         UserDetails user=null;
 
         try {
-            if(mainResource.equals("super") || mainResource.equals("admin")){
+            if(mainResource.equals("super") || mainResource.equals("admin") || mainResource.equals("site")){
                 AdminDTO byId = adminService.findById(Long.valueOf(id));
                 user = adminService.loadUserByUsername(byId.getUsername());
             }else if(mainResource.equals("subject")){

--- a/backend/src/main/java/com/tukorea/cogTest/service/AdminServiceImpl.java
+++ b/backend/src/main/java/com/tukorea/cogTest/service/AdminServiceImpl.java
@@ -123,6 +123,7 @@ public class AdminServiceImpl implements AdminService {
 
     public AdminDTO addAdmin(AdminForm adminForm) {
         Field selectedField = fieldRepository.findById(adminForm.getFieldId());
+        selectedField.appendWorkerNum();
         Admin admin = Admin.builder()
                 .name(adminForm.getName())
                 .username(adminForm.getUsername())

--- a/backend/src/main/java/com/tukorea/cogTest/service/AdminServiceImpl.java
+++ b/backend/src/main/java/com/tukorea/cogTest/service/AdminServiceImpl.java
@@ -147,14 +147,6 @@ public class AdminServiceImpl implements AdminService {
     }
 
     public void deleteAdmin(Long id) throws RuntimeException{
-        Admin byId = adminRepository.findById(id);
-        Field field = byId.getField();
-        if(field!=null){
-            List<Subject> byFieldId = subjectRepository.findByField_id(field.getId());
-            for (Subject subject : byFieldId) {
-                subjectRepository.delete(subject.getId());
-            }
-        }
         adminRepository.delete(id);
     }
 

--- a/backend/src/main/java/com/tukorea/cogTest/service/SubjectServiceImpl.java
+++ b/backend/src/main/java/com/tukorea/cogTest/service/SubjectServiceImpl.java
@@ -11,12 +11,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
+@Transactional
 public class SubjectServiceImpl implements SubjectService {
     private final SubjectRepository subjectRepository;
     private final TestResultRepository testResultRepository;
@@ -94,10 +96,9 @@ public class SubjectServiceImpl implements SubjectService {
      * @throws IllegalArgumentException : 피험자가 test result를 가지고 있지 않으면 발생한다.
      */
     public void delete(Long subjectId) throws IllegalArgumentException {
-        List<TestResult> byUserId = testResultRepository.findByUserId(subjectId);
-        if (byUserId != null) {
-            testResultRepository.deleteAllBySubjectId(subjectId);
-            subjectRepository.delete(subjectId);
-        }
+        Subject byId = subjectRepository.findById(subjectId);
+        byId.getField().decreaseWorkerNum();
+        subjectRepository.save(byId);
+        subjectRepository.delete(subjectId);
     }
 }


### PR DESCRIPTION
admin 삭제 시 admin만 삭제하도록 변경함.

site는 jwtFilter에서 토큰을 인증하고 인가 토큰을 부여할 때 resource가 site라면 adminService에서 로그인한 super admin을 가져오도록 설정